### PR TITLE
Add hash extension check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.1",
+        "ext-hash": "*",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0",
         "psr/http-server-middleware": "^1.0"


### PR DESCRIPTION
According to the [hash extension installation reference](https://www.php.net/manual/en/hash.installation.php), it seems that the `hash` extension will not be loaded probably at some moments.

This package always needs to use this extension to generate a `sha-256` token. And it should add `ext-hash` to check this extension is loaded.